### PR TITLE
modified: 쿼리 수정 및 프론트 게시글 id 파싱 에러 해결

### DIFF
--- a/src/main/java/com/single/springboard/domain/comments/CommentsRepository.java
+++ b/src/main/java/com/single/springboard/domain/comments/CommentsRepository.java
@@ -1,19 +1,8 @@
 package com.single.springboard.domain.comments;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface CommentsRepository extends JpaRepository<Comments, Long> {
-
-    @Query("select c from Comments c where c.posts.id = :postId order by c.parentComment.id asc, c.id desc")
-    List<Comments> findAllByComments(@Param("postId") Long postId);
-
-    @Query("select c from Comments c where c.posts.id = :postId and c.id = :parentId")
-    Optional<Comments> findByPostIdAndParentId(@Param("postId") Long postId, @Param("parentId") Long parentId);
 }

--- a/src/main/java/com/single/springboard/domain/user/User.java
+++ b/src/main/java/com/single/springboard/domain/user/User.java
@@ -1,6 +1,7 @@
 package com.single.springboard.domain.user;
 
 import com.single.springboard.domain.comments.Comments;
+import com.single.springboard.domain.posts.Posts;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -33,8 +34,11 @@ public class User {
     @Column(nullable = false)
     private Role role;
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE,orphanRemoval = true)
     private List<Comments> comments;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Posts> posts;
 
     public User update(String name, String picture) {
         this.name = name;

--- a/src/main/java/com/single/springboard/service/comments/CommentsService.java
+++ b/src/main/java/com/single/springboard/service/comments/CommentsService.java
@@ -12,7 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Optional;
+import java.util.Objects;
 
 import static com.single.springboard.exception.ErrorCode.NOT_FOUND_POST;
 import static com.single.springboard.exception.ErrorCode.NOT_FOUND_USER;
@@ -33,10 +33,7 @@ public class CommentsService {
 
         Comments comment;
 
-        Optional<Comments> parentComment = commentsRepository.findByPostIdAndParentId(
-                requestDto.postId(), requestDto.parentId());
-
-        if(parentComment.isEmpty()) {
+        if(requestDto.parentId() == null) {
             comment = Comments.builder()
                     .user(user)
                     .content(requestDto.content())
@@ -46,13 +43,17 @@ public class CommentsService {
                     .commentLevel(1)
                     .build();
         } else {
+            Comments parent = post.getComments().stream()
+                    .filter(c -> Objects.equals(c.getId(), requestDto.parentId()))
+                    .findFirst().get();
+
             comment = Comments.builder()
                     .user(user)
                     .content(requestDto.content())
                     .secret(requestDto.secret())
                     .posts(post)
-                    .parentComment(parentComment.get())
-                    .commentLevel(parentComment.get().getCommentLevel() + 1)
+                    .parentComment(parent)
+                    .commentLevel(parent.getCommentLevel() + 1)
                     .build();
         }
 

--- a/src/main/java/com/single/springboard/service/comments/CommentsUtils.java
+++ b/src/main/java/com/single/springboard/service/comments/CommentsUtils.java
@@ -11,6 +11,11 @@ public class CommentsUtils {
     public List<Comments> commentsSort(List<Comments> comments) {
         List<Comments> sortedComments = new ArrayList<>();
 
+        Collections.sort(comments, (Comments c1, Comments c2) -> {
+            if(c1.getId() < c2.getId()) return 1;
+            else return -1;
+        });
+
         for(Comments comment : comments) {
             if(comment.getParentComment() == null) {
                 sortedComments.add(comment);

--- a/src/main/java/com/single/springboard/service/posts/PostsService.java
+++ b/src/main/java/com/single/springboard/service/posts/PostsService.java
@@ -68,7 +68,7 @@ public class PostsService {
             postsUtils.increasePostViewCount(String.valueOf(id), user.email());
         }
 
-        List<Comments> comments = commentsRepository.findAllByComments(post.getId());
+        List<Comments> comments = post.getComments();
         List<Comments> sortedComments = commentsUtils.commentsSort(comments);
 
         List<CommentsResponse> commentsResponses = sortedComments.stream()

--- a/src/main/resources/static/js/app/comments.js
+++ b/src/main/resources/static/js/app/comments.js
@@ -14,9 +14,11 @@ var main = {
     save : function () {
         const secretCheckBox = document.getElementsByClassName('comment-secretYn');
         const checked = $(secretCheckBox).is(':checked');
+        const url = window.location.href;
+        const match = url.match(/\/(\d+)(?:\?|$)/);
 
         let data = {
-            postId: window.location.href.split("/").pop().substring(0, 1),
+            postId: match[1],
             nickname: $('#comment-author').text(),
             content: $('#comment-content').val(),
             secret: checked
@@ -42,9 +44,11 @@ var main = {
         const content = $(parentDiv).children().first().val();
         const secretCheckBox = $(parentDiv).children().last();
         const checked = $(secretCheckBox).is(':checked');
+        const url = window.location.href;
+        const match = url.match(/\/(\d+)(?:\?|$)/);
 
         let data = {
-            postId: window.location.href.split("/").pop().substring(0, 1),
+            postId: match[1],
             parentId: ancestorLiId,
             nickname: $('#comment-author').text(),
             content,


### PR DESCRIPTION
Changes
---
front
- 댓글을 저장할 때 게시글 id를 url에서 파싱하는 부분에서 다른 문자열까지 파싱되어 에러 발생. 정규식으로 필터링 후 해결

back
- CommentsRepository에 있던 불필요한 쿼리 삭제. 