### PR TITLE
test: PostsApiController 테스트 코드 작성

### DIFF
--- a/src/main/java/com/single/springboard/SpringBoardApplication.java
+++ b/src/main/java/com/single/springboard/SpringBoardApplication.java
@@ -4,7 +4,6 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableScheduling
 @SpringBootApplication
 public class SpringBoardApplication {
 

--- a/src/main/java/com/single/springboard/web/PostsApiController.java
+++ b/src/main/java/com/single/springboard/web/PostsApiController.java
@@ -5,12 +5,9 @@ import com.single.springboard.config.auth.dto.SessionUser;
 import com.single.springboard.service.posts.PostsService;
 import com.single.springboard.web.dto.posts.PostSaveRequest;
 import com.single.springboard.web.dto.posts.PostUpdateRequest;
-import com.single.springboard.web.dto.posts.PostsResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
@@ -29,14 +26,6 @@ public class PostsApiController {
             @ModelAttribute @Valid PostSaveRequest requestDto,
             @LoginUser SessionUser user) {
         return postsService.savePostAndFiles(requestDto, user.email());
-    }
-
-    @PreAuthorize("isAuthenticated()")
-    @GetMapping
-    public ResponseEntity<Page<PostsResponse>> findAllPosts(Pageable pageable) {
-
-        Page<PostsResponse> posts = postsService.findAllPostsAndCommentsCountDesc(pageable);
-        return ResponseEntity.ok(posts);
     }
 
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")

--- a/src/main/java/com/single/springboard/web/dto/posts/PostUpdateRequest.java
+++ b/src/main/java/com/single/springboard/web/dto/posts/PostUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.single.springboard.web.dto.posts;
 
-import com.single.springboard.domain.files.Files;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/test/java/com/single/springboard/web/PostsApiControllerTest.java
+++ b/src/test/java/com/single/springboard/web/PostsApiControllerTest.java
@@ -1,0 +1,218 @@
+package com.single.springboard.web;
+
+import com.single.springboard.config.auth.dto.SessionUser;
+import com.single.springboard.domain.user.Role;
+import com.single.springboard.domain.user.User;
+import com.single.springboard.service.posts.PostsService;
+import com.single.springboard.web.dto.posts.PostSaveRequest;
+import com.single.springboard.web.dto.posts.PostUpdateRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(PostsApiController.class)
+class PostsApiControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PostsService postsService;
+
+    @Test
+    @WithMockUser(username = "user", roles = "USER")
+    void savePost_authorize_success() throws Exception {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "file",         // 파일 파라미터 이름
+                "image.png", // 파일 이름
+                MediaType.IMAGE_PNG_VALUE,
+                "Hello world!".getBytes()
+        );
+        User user = User.builder()
+                .email("testuser@naver.com")
+                .name("user")
+                .id(1L)
+                .picture(null)
+                .role(Role.USER)
+                .build();
+
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        mockHttpSession.setAttribute("user", new SessionUser(user));
+
+        PostSaveRequest requestDto = new PostSaveRequest("title", "content", "author", null);
+        given(postsService.savePostAndFiles(requestDto, user.getEmail()))
+                .willReturn(1L);
+
+        // when
+        // then
+        mockMvc.perform(multipart("/api/v1/posts")
+                        .file(file)
+                        .param("title", requestDto.title())
+                        .param("author", requestDto.author())
+                        .param("content", requestDto.content())
+                        .contentType("multipart/form-data")
+                        .session(mockHttpSession)
+                        .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("1"));
+
+        verify(postsService, times(1)).savePostAndFiles(requestDto, user.getEmail());
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = "USER")
+    void savePost_postTitleIsBlank_failed() throws Exception {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "file",         // 파일 파라미터 이름
+                "image.png", // 파일 이름
+                MediaType.IMAGE_PNG_VALUE,
+                "Hello world!".getBytes()
+        );
+        User user = User.builder()
+                .email("testuser@naver.com")
+                .name("user")
+                .id(1L)
+                .picture(null)
+                .role(Role.USER)
+                .build();
+
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        mockHttpSession.setAttribute("user", new SessionUser(user));
+
+        PostSaveRequest requestDto = new PostSaveRequest("", "content", "author", null);
+
+        // when
+        // then
+        mockMvc.perform(multipart("/api/v1/posts")
+                        .file(file)
+                        .param("title", requestDto.title())
+                        .param("author", requestDto.author())
+                        .param("content", requestDto.content())
+                        .contentType("multipart/form-data")
+                        .session(mockHttpSession)
+                        .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("제목은 띄어쓰기만 있을 수 없습니다. 한 글자 이상 입력해 주세요."))
+                .andExpect(jsonPath("$.errorCode").value(400));
+
+        verify(postsService, times(0)).savePostAndFiles(requestDto, user.getEmail());
+    }
+
+    @Test
+    @WithAnonymousUser
+    void savePost_unauthorized_failed() throws Exception {
+        // given
+        MockMultipartFile file = new MockMultipartFile(
+                "file",         // 파일 파라미터 이름
+                "image.png", // 파일 이름
+                MediaType.IMAGE_PNG_VALUE,
+                "Hello world!".getBytes()
+        );
+
+        PostSaveRequest requestDto = new PostSaveRequest("title", "content", "author", null);
+
+        // when
+        // then
+        mockMvc.perform(multipart("/api/v1/posts")
+                        .file(file)
+                        .param("title", requestDto.title())
+                        .param("author", requestDto.author())
+                        .param("content", requestDto.content())
+                        .contentType("multipart/form-data")
+                        .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().is3xxRedirection());
+
+        verify(postsService, times(0)).savePostAndFiles(requestDto, null);
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = "USER")
+    void updatePost_authorize_success() throws Exception {
+        // given
+        Long postId = 1L;
+        PostUpdateRequest updateDto = new PostUpdateRequest("title", "author", "content", null);
+
+        User user = User.builder()
+                .email("testuser@naver.com")
+                .name("user")
+                .id(1L)
+                .picture(null)
+                .role(Role.USER)
+                .build();
+
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        mockHttpSession.setAttribute("user", new SessionUser(user));
+        given(postsService.updatePost(postId, updateDto))
+                .willReturn(1L);
+
+        // when
+        // then
+        mockMvc.perform(patch("/api/v1/posts/{id}", postId)
+                        .param("title", updateDto.title())
+                        .param("author", updateDto.author())
+                        .param("content", updateDto.content())
+                        .session(mockHttpSession)
+                        .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("1"));
+
+        verify(postsService, times(1)).updatePost(1L, updateDto);
+    }
+
+    @Test
+    @WithMockUser(username = "user", roles = "USER")
+    void deletePost_authorize_success() throws Exception {
+        // given
+        Long postId = 1L;
+
+        User user = User.builder()
+                .email("testuser@naver.com")
+                .name("user")
+                .id(1L)
+                .picture(null)
+                .role(Role.USER)
+                .build();
+
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        mockHttpSession.setAttribute("user", new SessionUser(user));
+        given(postsService.deletePostWithFiles(postId))
+                .willReturn(true);
+
+        // when
+        // then
+        mockMvc.perform(delete("/api/v1/posts/{id}", postId)
+                        .session(mockHttpSession)
+                        .with(csrf())
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().string("1"));
+
+        verify(postsService, times(1)).deletePostWithFiles(1L);
+    }
+}


### PR DESCRIPTION
Changes
---
- PostsApiController에 대한 테스트 코드 작성
- PostsApiController에 findAllPosts 메서드 제거. index controller에서 동일한 기능을 수행하는 메서드가 있기 때문

Background
---
- SpringSecurity를 사용하고 있을 때에  사용자 인가를 위해 @WithMockUser어노테이션을 사용하여 인가 처리
- session을 이용하여 요청을 보낼 때 .with(csrf()) 설정을 해주지 않으면 403forbidden error가 발생. 스프링 시큐리티에서 기본적으로 csrf토큰이 포함되지 않은 요청이 올 경우 거부하기 때문에 해당 에러가 발생된다.
