### PR TITLE
modified:메인 페이지와 게시글 read 페이지에 fetch join을 이용한 성능 최적화

### DIFF
--- a/src/main/java/com/single/springboard/domain/post/PostRepository.java
+++ b/src/main/java/com/single/springboard/domain/post/PostRepository.java
@@ -4,9 +4,16 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
-    @Query("SELECT p, COUNT(c) FROM Post p LEFT JOIN Comment c ON p.id = c.post.id GROUP BY p ORDER BY p.id DESC ")
-    Page<Object[]> findAllPostsWithCommentsCount(Pageable pageable);
+    @Query("SELECT p, COUNT(pc) FROM Post p " +
+            "LEFT JOIN FETCH p.comments pc " +
+            "LEFT JOIN FETCH p.user " +
+            "GROUP BY p " +
+            "ORDER BY p.id DESC")
+    Page<Object[]> findAllPostsWithCommentsCountAndUser(Pageable pageable);
 
+    @Query("SELECT p from Post p LEFT JOIN FETCH p.comments c LEFT JOIN FETCH c.user where p.id = :postId")
+    Post findPostWithCommentsAndUser(@Param("postId") Long postId);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,6 +12,7 @@ spring.data.web.pageable.max-page-size=20
 
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL8Dialect
+spring.jpa.properties.hibernate.format_sql=true
 
 spring.data.redis.host=localhost
 spring.data.redis.port=6379


### PR DESCRIPTION
Changes
---
- 메인페이지 게시글에 대하여 작성자 수 만큼의 쿼리가 추가적으로 발생(N + 1 문제)하여 fetch join을 이용하여 하나의 쿼리로 통합(post, comment, user)
- 게시글을 읽을 때 게시글에 대한 댓글 수 만큼 쿼리가 추가적으로 발생하여 fetch join을 이용하여 하나의 쿼리로 통합.(post, user, comment) Post객체는 comment와 file에 대한 관계가 toMany관계이기 때문에 file까지 fetch join을 하게 되면 
`cannot simultaneously fetch multiple bags` 에러가 발생되기 때문에 file은 지연 로딩을 통하여 가져오게되어 쿼리가 추가적으로 발생됨. 그러므로 총 2개의 쿼리가 발생.

Background
---
- 쿼리 성능 최적화에 대한 공부(fetch join, jpa batch fetching)
- N + 1 문제에 대한 이해 및 해결 방안에 대한 공부