### PR TITLE
fix: 메인 페이지 댓글 카운트 쿼리 오류로 postRepository 쿼리 수정

### DIFF
--- a/src/main/java/com/single/springboard/domain/post/PostRepository.java
+++ b/src/main/java/com/single/springboard/domain/post/PostRepository.java
@@ -7,13 +7,17 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
-    @Query("SELECT p, COUNT(pc) FROM Post p " +
-            "LEFT JOIN FETCH p.comments pc " +
+    @Query("SELECT p, COUNT(c) FROM Post p " +
+            "LEFT JOIN p.comments c " +
             "LEFT JOIN FETCH p.user " +
             "GROUP BY p " +
             "ORDER BY p.id DESC")
     Page<Object[]> findAllPostsWithCommentsCountAndUser(Pageable pageable);
 
-    @Query("SELECT p from Post p LEFT JOIN FETCH p.comments c LEFT JOIN FETCH c.user where p.id = :postId")
+    @Query("SELECT p from Post p " +
+            "LEFT JOIN FETCH p.comments c " +
+            "LEFT JOIN FETCH c.user " +
+            "LEFT JOIN FETCH p.user " +
+            "where p.id = :postId")
     Post findPostWithCommentsAndUser(@Param("postId") Long postId);
 }


### PR DESCRIPTION
Changes
---
- 메인 페이지 댓글 카운트 수에 대한 쿼리 오류로 수정.(comments는 count만 해주면 되기 때문에 fetch를 사용할 필요 없음.)