### PR TITLE
fix: 임시 사용자 이름 카운트 증감 시 루아 스크립트를 이용한 레이스 컨디션 방지

### DIFF
--- a/src/main/java/com/single/springboard/config/LoadScriptConfig.java
+++ b/src/main/java/com/single/springboard/config/LoadScriptConfig.java
@@ -1,0 +1,16 @@
+package com.single.springboard.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.data.redis.core.script.RedisScript;
+
+@Configuration
+public class LoadScriptConfig {
+
+    @Bean
+    public RedisScript<String> temporaryUserIncrScript() {
+        return RedisScript.of(new ClassPathResource("scripts/temporaryUserIncr.lua"), String.class);
+    }
+}
+

--- a/src/main/java/com/single/springboard/config/SecurityConfig.java
+++ b/src/main/java/com/single/springboard/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import org.springframework.security.config.annotation.web.configurers.CsrfConfig
 import org.springframework.security.config.annotation.web.configurers.FormLoginConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
 @EnableMethodSecurity
@@ -35,10 +36,12 @@ public class SecurityConfig {
                                 .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
                 )
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/", "/css/**", "/images/**", "/h2-console/**",
-                                "/js/**", "/posts/find/**", "/search/**", "/actuator/health")
+                        .requestMatchers(new AntPathRequestMatcher("/h2-console/**"))
                         .permitAll()
-                        .requestMatchers("/api/v1/comments/**", "/api/v1/posts/**")
+                        .requestMatchers("/", "/css/**", "/images/**", "/js/**",
+                                "/posts/find/**", "/search/**", "/actuator/health")
+                        .permitAll()
+                        .requestMatchers("/api/v1/**")
                         .hasRole(Role.USER.name())
                         .anyRequest().authenticated())
                 .anonymous(anonymous -> {
@@ -50,7 +53,6 @@ public class SecurityConfig {
                 .logout(logoutConfigurer ->
                         logoutConfigurer
                                 .logoutSuccessUrl("/")
-                                .clearAuthentication(true)
                                 .invalidateHttpSession(true)
                 )
                 .oauth2Login(oAuth2LoginConfigurer -> {

--- a/src/main/java/com/single/springboard/service/post/PostService.java
+++ b/src/main/java/com/single/springboard/service/post/PostService.java
@@ -54,10 +54,8 @@ public class PostService {
 
         Post post = postRepository.save(requestDto.toEntity(user));
 
-        List<File> files = new ArrayList<>();
-
         if (requestDto.files() != null) {
-            files.addAll(fileService.postFilesSave(post, requestDto.files()));
+            List<File> files = new ArrayList<>(fileService.postFilesSave(post, requestDto.files()));
         }
 
         return post.getId();

--- a/src/main/java/com/single/springboard/web/UserApiController.java
+++ b/src/main/java/com/single/springboard/web/UserApiController.java
@@ -19,7 +19,6 @@ public class UserApiController {
 
     private final CustomOAuth2UserService oAuth2UserService;
 
-    @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @PatchMapping
     public ResponseEntity<Void> userInfoUpdate(@ModelAttribute UserUpdateRequest requestDto,
                                                @LoginUser SessionUser user

--- a/src/main/resources/scripts/temporaryUserIncr.lua
+++ b/src/main/resources/scripts/temporaryUserIncr.lua
@@ -1,0 +1,6 @@
+local key = KEYS[1]
+local increment = tonumber(ARGV[1])
+local current_value = tonumber(redis.call('GET', key) or 0)
+current_value = current_value + increment
+redis.call('SET', key, current_value)
+return tostring(current_value)


### PR DESCRIPTION
Changes
---
- 기존 redisTemplate의 opsForValue를 이용하여 임시 사용자 이름 카운트 증감(사용자1, 사용자2...)을 하였으나, 동시성 문제가 발생할 우려가 있기 때문에 lua script를 이용하여 일관성 유지.

Background
---
- lua script 및 redis 실행 방식에 대한 공부 및 이해
- redis는 단일 스레드 모델이기 때문에 여러 사용자가 동시에 요청을 해도 순차적으로 진행할 수 있기 때문에 lua script를 이용.