### PR TITLE
fix: 게시글 업데이트 시 반영이 되지 않는 문제 수정 진행 중

### DIFF
--- a/src/main/java/com/single/springboard/SpringBoardApplication.java
+++ b/src/main/java/com/single/springboard/SpringBoardApplication.java
@@ -2,7 +2,6 @@ package com.single.springboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 public class SpringBoardApplication {

--- a/src/main/java/com/single/springboard/domain/file/FileRepository.java
+++ b/src/main/java/com/single/springboard/domain/file/FileRepository.java
@@ -3,13 +3,18 @@ package com.single.springboard.domain.file;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FileRepository extends JpaRepository<File, Long> {
     @Modifying(clearAutomatically = true)
     @Query("delete from File f where f.post.id = :postId")
-    void deleteFiles(Long postId);
+    void deleteFiles(@Param("postId") Long postId);
 
-    List<File> findAllByPostId(Long postId);
+    Optional<File> findByTranslateName(String translateName);
+
+    @Query("select f from File f where f.post.id = :postId")
+    List<File> findAllFileByPost(@Param("postId") Long postId);
 }

--- a/src/main/java/com/single/springboard/domain/post/Post.java
+++ b/src/main/java/com/single/springboard/domain/post/Post.java
@@ -42,12 +42,16 @@ public class Post extends BaseTimeEntity {
 
     private long viewCount;
 
-    public void updatePost(PostUpdateRequest updateDto) {
-        this.title = updateDto.title();
-        this.content = updateDto.content();
+    public void updatePost(PostUpdateRequest updateRequest) {
+        this.title = updateRequest.title();
+        this.content = updateRequest.content();
     }
 
-    public void updateViewCount() {
+    public void updatePostFiles(List<File> files) {
+        this.files = files;
+    }
+
+    public void increaseViewCount() {
         this.viewCount += 1;
     }
 }

--- a/src/main/java/com/single/springboard/domain/post/PostRepository.java
+++ b/src/main/java/com/single/springboard/domain/post/PostRepository.java
@@ -20,4 +20,9 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRep
             "LEFT JOIN FETCH p.user " +
             "where p.id = :postId")
     Post findPostWithCommentsAndUser(@Param("postId") Long postId);
+
+    @Query("SELECT p from Post p " +
+            "LEFT JOIN fetch p.files " +
+            "where p.id = :postId")
+    Post findPostWithFiles(@Param("postId") Long postId);
 }

--- a/src/main/java/com/single/springboard/domain/user/UserRepository.java
+++ b/src/main/java/com/single/springboard/domain/user/UserRepository.java
@@ -8,6 +8,5 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
-    Optional<User> findByName(String name);
     boolean existsByName(String name);
 }

--- a/src/main/java/com/single/springboard/service/file/AwsS3Upload.java
+++ b/src/main/java/com/single/springboard/service/file/AwsS3Upload.java
@@ -1,7 +1,7 @@
 package com.single.springboard.service.file;
 
 import com.single.springboard.domain.file.File;
-import com.single.springboard.util.FilesUtils;
+import com.single.springboard.util.FileUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -22,7 +22,7 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class AwsS3Upload {
-    private final FilesUtils filesUtils;
+    private final FileUtils fileUtils;
     private final S3Client s3Client;
 
     @Value("${cloud.aws.s3.bucket}")
@@ -34,7 +34,7 @@ public class AwsS3Upload {
         PutObjectRequest putObj;
 
         for (MultipartFile file : files) {
-            String keyName = filesUtils.translateSaveFileName(file.getOriginalFilename());
+            String keyName = fileUtils.translateFileName(file.getOriginalFilename());
 
             putObj = PutObjectRequest.builder()
                     .bucket(bucket)

--- a/src/main/java/com/single/springboard/service/file/FileService.java
+++ b/src/main/java/com/single/springboard/service/file/FileService.java
@@ -3,26 +3,30 @@ package com.single.springboard.service.file;
 import com.single.springboard.domain.file.File;
 import com.single.springboard.domain.file.FileRepository;
 import com.single.springboard.domain.post.Post;
-import com.single.springboard.util.FilesUtils;
+import com.single.springboard.service.file.dto.FilesNameDto;
+import com.single.springboard.util.FileUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class FileService {
     private final FileRepository fileRepository;
-    private final FilesUtils filesUtils;
+    private final FileUtils fileUtils;
     private final AwsS3Upload s3Upload;
 
     @Transactional
     public List<File> postFilesSave(Post post, List<MultipartFile> multipartFiles) {
-        List<MultipartFile> files = filesUtils.fileMimeTypeCheck(multipartFiles);
+        fileUtils.fileMimeTypeCheck(multipartFiles);
 
-        List<File> fileEntities = s3Upload.uploadFile(files);
+        List<File> fileEntities = s3Upload.uploadFile(multipartFiles);
         for(File file : fileEntities) {
             file.setPost(post);
         }
@@ -31,17 +35,47 @@ public class FileService {
     }
 
     @Transactional
-    public String profileImageUpdate(List<MultipartFile> multipartFile) {
-        List<MultipartFile> file = filesUtils.fileMimeTypeCheck(multipartFile);
+    public List<File> filesUpdate(List<File> oldFiles, List<MultipartFile> newFiles, HashMap<Long, String> oldFileNames) {
+        fileUtils.fileMimeTypeCheck(newFiles);
 
-        List<File> fileEntity = s3Upload.uploadFile(file);
+        List<File> toBeDeleteFiles = findDeleteFiles(oldFiles, oldFileNames);
 
-        return fileEntity.get(0).getTranslateName();
+        if(!oldFiles.isEmpty()) {
+            s3Upload.delete(toBeDeleteFiles);
+            if(oldFiles.size() > 1) {
+                fileRepository.deleteFiles(toBeDeleteFiles.get(0).getPost().getId());
+            } else {
+                fileRepository.delete(toBeDeleteFiles.get(0));
+            }
+        }
+
+        return s3Upload.uploadFile(newFiles);
+    }
+
+    public List<FilesNameDto> getFilesOfPost(Long postId) {
+        return fileRepository.findAllFileByPost(postId).stream()
+                .map(file -> new FilesNameDto(file.getId(), file.getOriginalName()))
+                .toList();
     }
 
     @Transactional
     public void deletePostChildFiles(Post post) {
         s3Upload.delete(post.getFiles());
         fileRepository.deleteFiles(post.getId());
+    }
+
+    public Optional<File> findByTranslateName(String name) {
+        return fileRepository.findByTranslateName(name);
+    }
+
+    public List<File> findDeleteFiles(List<File> existFiles, HashMap<Long, String> fileNames) {
+        List<File> willBeDeleteFiles = new ArrayList<>();
+        for(File file : existFiles) {
+            if(!fileNames.containsValue(file.getOriginalName())) {
+                willBeDeleteFiles.add(file);
+            }
+        }
+
+        return willBeDeleteFiles;
     }
 }

--- a/src/main/java/com/single/springboard/service/file/dto/FilesNameDto.java
+++ b/src/main/java/com/single/springboard/service/file/dto/FilesNameDto.java
@@ -1,0 +1,10 @@
+package com.single.springboard.service.file.dto;
+
+import lombok.Builder;
+
+@Builder
+public record FilesNameDto(
+        Long id,
+        String originalName
+) {
+}

--- a/src/main/java/com/single/springboard/util/CommentUtils.java
+++ b/src/main/java/com/single/springboard/util/CommentUtils.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component;
 import java.util.*;
 
 @Component
-public class CommentsUtils {
+public class CommentUtils {
 
     public List<Comment> commentsSort(List<Comment> comments) {
         List<Comment> sortedComments = new ArrayList<>();

--- a/src/main/java/com/single/springboard/util/FileUtils.java
+++ b/src/main/java/com/single/springboard/util/FileUtils.java
@@ -12,18 +12,17 @@ import java.util.UUID;
 
 @Slf4j
 @Component
-public class FilesUtils {
-    public List<MultipartFile> fileMimeTypeCheck(final List<MultipartFile> multipartFiles) {
+public class FileUtils {
+    public void fileMimeTypeCheck(final List<MultipartFile> multipartFiles) {
         for(MultipartFile multipartFile : multipartFiles) {
             String mimeType = getMimeType(multipartFile);
             if(!validImageMimeType(mimeType)) {
                 throw new RuntimeException("이미지 파일만 업로드 가능합니다.");
             }
         }
-        return multipartFiles;
     }
 
-    public String translateSaveFileName(final String fileName) {
+    public String translateFileName(final String fileName) {
         String uuid = UUID.randomUUID().toString().replace("-", "");
         String extension = StringUtils.getFilenameExtension(fileName);
         return uuid + "." + extension;

--- a/src/main/java/com/single/springboard/util/UserUtils.java
+++ b/src/main/java/com/single/springboard/util/UserUtils.java
@@ -1,0 +1,21 @@
+package com.single.springboard.util;
+
+import lombok.AllArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+
+@Component
+@AllArgsConstructor
+public class UserUtils {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisScript<String> temporaryUserIncrScript;
+
+    public String getTemporaryUserNumber() {
+        String increment = "1";
+        return redisTemplate.execute(temporaryUserIncrScript,
+                Collections.singletonList("temporaryUserNumber"), increment);
+    }
+}

--- a/src/main/java/com/single/springboard/web/FileApiController.java
+++ b/src/main/java/com/single/springboard/web/FileApiController.java
@@ -1,0 +1,24 @@
+package com.single.springboard.web;
+
+import com.single.springboard.service.file.FileService;
+import com.single.springboard.service.file.dto.FilesNameDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/files")
+@RestController
+public class FileApiController {
+    private final FileService fileService;
+
+    @GetMapping("/{postId}")
+    public List<FilesNameDto> getPostFiles(@PathVariable Long postId) {
+        return fileService.getFilesOfPost(postId);
+    }
+
+}

--- a/src/main/java/com/single/springboard/web/IndexController.java
+++ b/src/main/java/com/single/springboard/web/IndexController.java
@@ -49,7 +49,6 @@ public class IndexController {
     public String postUpdate(@PathVariable Long id, Model model, @LoginUser SessionUser user) {
         PostResponse post = postService.findPostById(id);
         model.addAttribute("post", post);
-        model.addAttribute("files", post.files());
 
         return "post-update";
     }

--- a/src/main/java/com/single/springboard/web/PostApiController.java
+++ b/src/main/java/com/single/springboard/web/PostApiController.java
@@ -13,7 +13,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
-@PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/posts")
 @RestController
@@ -30,6 +29,7 @@ public class PostApiController {
 
     @PatchMapping("/{id}")
     public Long updatePost(@PathVariable Long id, @ModelAttribute @Valid PostUpdateRequest updateDto) {
+
         return postService.updatePost(id, updateDto);
     }
 

--- a/src/main/java/com/single/springboard/web/dto/post/PostUpdateRequest.java
+++ b/src/main/java/com/single/springboard/web/dto/post/PostUpdateRequest.java
@@ -1,5 +1,6 @@
 package com.single.springboard.web.dto.post;
 
+import com.single.springboard.service.file.dto.FilesNameDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,7 +17,9 @@ public record PostUpdateRequest(
         @NotEmpty(message = "수정하실 게시글 내용을 입력 해주세요.")
         String content,
 
-        List<MultipartFile> files
+        List<MultipartFile> files,
+
+        List<String> oldFileNames
 ) {
 
 }

--- a/src/main/resources/static/js/app/comment.js
+++ b/src/main/resources/static/js/app/comment.js
@@ -1,4 +1,4 @@
-var main = {
+let comment = {
     init : function () {
         var _this = this;
         $('.btn-save').on('click', () => {
@@ -119,4 +119,4 @@ var main = {
 };
 
 
-main.init();
+comment.init();

--- a/src/main/resources/static/js/app/file.js
+++ b/src/main/resources/static/js/app/file.js
@@ -1,0 +1,61 @@
+let oldFileArr = [];
+
+const init = function () {
+    const url = window.location.href;
+    const match = url.match(/\/(\d+)(?:\?|$)/);
+
+    const postId = match[1];
+
+    $(document).ready(() => {
+        $.ajax({
+            type: 'GET',
+            url: "/api/v1/files/" + postId,
+            success: (data) => {
+                this.displayFileName(data);
+            },
+            error: () => {
+                alert("파일을 가져오는데 실패 하였습니다.");
+                return false;
+            }
+        })
+    })
+}
+
+function displayFileName (fileNameArr) {
+    for (let i = 0; i < fileNameArr.length; i++) {
+        let file = fileNameArr[i];
+        oldFileArr.push(file);
+        const fileName = file.originalName;
+        const div = document.createElement("div");
+        div.className = "file";
+        div.style.display = "flex";
+        div.style.justifyContent = "space-between";
+        div.style.marginBottom = "10px";
+        const fileNameSpan = document.createElement("span");
+        fileNameSpan.innerText = fileName;
+        const delBtn = document.createElement("button");
+        delBtn.className = "del-image_btn btn btn-danger";
+        delBtn.innerText = "삭제";
+        delBtn.addEventListener('click', (e) => {
+            deleteFile(e);
+        })
+        div.appendChild(fileNameSpan);
+        div.appendChild(delBtn);
+        const dropZone = $("#drop-zone");
+        dropZone.append(div);
+    }
+}
+
+function deleteFile (e) {
+    e.stopPropagation();
+
+    const filename = e.target.parentNode.childNodes[0].outerText;
+
+    newFileArr = newFileArr.filter(item => filename !== item.name);
+    oldFileArr = oldFileArr.filter(item => filename !== item.name);
+
+    const fileElement = e.target.parentNode;
+    fileElement.remove();
+}
+
+init();

--- a/src/main/resources/static/js/app/post.js
+++ b/src/main/resources/static/js/app/post.js
@@ -1,7 +1,8 @@
-let fileArr = [];
-var main = {
+let newFileArr = [];
+
+let post = {
     init : function() {
-        var _this = this;
+        let _this = this;
         $('.post-save_btn').on('click', () => {
             _this.save();
         });
@@ -20,7 +21,7 @@ var main = {
         })
 
         $('.del-image_btn').on('click', (e) => {
-            _this.deleteFile(e);
+            deleteFile(e);
         })
 
         $('#drop-zone').on('dragover', (e) => {
@@ -58,7 +59,7 @@ var main = {
 
     },
     save : function() {
-        const formData = this.createFormData();
+        const formData = this.createForm();
 
         $.ajax({
             type: 'POST',
@@ -78,12 +79,17 @@ var main = {
     },
 
     update : function () {
-        const formData = this.createFormData();
+        const formData = this.createForm();
+        let oldFileObj = {};
+        for (let i = 0; i < oldFileArr.length; i++) {
+            oldFileObj
+        }
+        formData.append('oldFileNames', JSON.stringify(oldFileObj));
 
         const id = $('#id').text();
 
         $.ajax({
-            type: 'PATCH',
+            method: 'PATCH',
             url: '/api/v1/posts/'+id,
             processData: false,
             contentType: false,
@@ -119,7 +125,7 @@ var main = {
         $("#drop-zone p").remove();
         for (let i = 0; i < files.length; i++) {
             let file = files[i];
-            fileArr.push(file);
+            newFileArr.push(file);
             const fileName = file.name;
             let fileSize = file.size / 1024 / 1024;
             fileSize = fileSize < 1 ? fileSize.toFixed(3) : fileSize.toFixed(1);
@@ -127,6 +133,7 @@ var main = {
             div.className = "file";
             div.style.display = "flex";
             div.style.justifyContent = "space-between";
+            div.style.marginBottom = "10px";
             const fileNameSpan = document.createElement("span");
             fileNameSpan.className = "fileName";
             fileNameSpan.innerText = fileName;
@@ -135,11 +142,9 @@ var main = {
             fileSizeSpan.innerText = fileSize + " MB";
             const delBtn = document.createElement("button");
             delBtn.className = "del-image_btn btn btn-danger";
-            delBtn.style.color = "while";
             delBtn.innerText = "삭제";
-            let _this = this;
             delBtn.addEventListener('click', (e) => {
-                _this.deleteFile(e);
+                deleteFile(e);
             })
             div.appendChild(fileNameSpan);
             div.appendChild(fileSizeSpan);
@@ -149,31 +154,17 @@ var main = {
         }
     },
 
-    deleteFile : function (e) {
-        e.stopPropagation();
-
-        const filename = e.target.parentNode.childNodes[0].outerText;
-
-        for (let i = 0; i < fileArr.length; i++) {
-            if(filename === fileArr[i].name) {
-                fileArr.splice(i);
-            }
-        }
-
-        const fileElement = e.target.parentNode;
-        fileElement.remove();
-    },
-
-    createFormData : function () {
+    createForm : function () {
         let formData = new FormData();
         formData.append('title', $('#title').val());
         formData.append('author', $('#author').text());
         formData.append('content', $('#content').val());
-        fileArr.forEach(file => {
-            formData.append('files', file)
+        newFileArr.forEach(file => {
+            formData.append('files', file);
         });
         return formData;
-    }
+    },
+
 };
 
-main.init();
+post.init();

--- a/src/main/resources/static/js/app/user.js
+++ b/src/main/resources/static/js/app/user.js
@@ -1,4 +1,4 @@
-var main = {
+let user = {
     init : function() {
         var _this = this;
         $('.user-update_btn').on('click', () => {
@@ -35,4 +35,4 @@ var main = {
     },
 };
 
-main.init();
+user.init();

--- a/src/main/resources/templates/post-update.html
+++ b/src/main/resources/templates/post-update.html
@@ -35,14 +35,6 @@
                 <form id="upload-form" enctype="multipart/form-data">
                     <input type="file" id="file-input" name="files" style="display: none;" accept="image/*" multiple/>
                     <div id="drop-zone" style="border: 2px dashed #aaa; padding: 30px; text-align: center;">
-                        <div th:each="file : ${files}" style="display: flex; justify-content: space-between; margin-top: 10px">
-                            <span th:text="${file.getOriginalName()}"></span>
-                            <button class="del-image_btn btn btn-danger" style="color: white">삭제</button>
-                        </div>
-                        <p th:if="${files.size() == 0}" style="opacity: 0.7" >
-                            여기를 클릭하거나 파일을 드래그앤드롭 하세요
-                            용량은 한 파일 당 10MB씩 50MB 까지 업로드가 가능합니다.
-                        </p>
                     </div>
                 </form>
             </div>
@@ -58,6 +50,7 @@
         integrity="sha256-pvPw+upLPUjgMXY0G+8O0xUf+/Im1MZjXxxgOcBQBXU="
         crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js"></script>
+<script src="/js/app/file.js"></script>
 <script src="/js/app/post.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fix
---
- 게시글의 이미지 파일 수정 시 반영이 정상적으로 되지 않음.
- 화면에서도 삭제 버튼 클릭 시 내역의 모든 파일이 전체 삭제되는 에러 발생

Changes
---
- 화면에서 삭제/추가 시 문제가 발생되었던 부분 수정 처리
- 기존에 게시글 생성 시 수정 화면에서 타임리프에서 바로 받아왔었으나 현재 ajax로 파일에 대한 부분은 따로 요청하여 불러오는 것으로 처리.(파일의 id와 originalName만 받아옴. 이유는 파일 자체를 불러오기에는 비용이 너무 비싼 것으로 판단.) 

Error
---
- 현재 프론트에서 formData를 이용하여 파일과 이전 파일에 대한 이름, id를 같이 백엔드로 PATCH처리 하게 되는데 백엔드에서 List<String> 타입으로 로드되어 해당 이슈 확인 중.