### PR TITLE
fix: 게시글 이미지 파일 업데이트 및 유저 프로필 파일 업데이트 로직 수정

### DIFF
--- a/src/main/java/com/single/springboard/domain/file/File.java
+++ b/src/main/java/com/single/springboard/domain/file/File.java
@@ -24,8 +24,13 @@ public class File {
     @JoinColumn(name = "post_id")
     private Post post;
 
+    @Column(nullable = false, updatable = false)
     private String originalName;
+
+    @Column(nullable = false, updatable = false)
     private String translateName;
+
+    @Column(nullable = false, updatable = false)
     private long size;
 
     @CreatedDate

--- a/src/main/java/com/single/springboard/domain/file/FileCustomRepository.java
+++ b/src/main/java/com/single/springboard/domain/file/FileCustomRepository.java
@@ -1,0 +1,10 @@
+package com.single.springboard.domain.file;
+
+import java.util.List;
+
+public interface FileCustomRepository {
+
+    void deleteFilesByIds(List<Long> ids);
+
+    List<String> findFilesByIds(List<Long> ids);
+}

--- a/src/main/java/com/single/springboard/domain/file/FileRepository.java
+++ b/src/main/java/com/single/springboard/domain/file/FileRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 import java.util.Optional;
 
-public interface FileRepository extends JpaRepository<File, Long> {
+public interface FileRepository extends JpaRepository<File, Long>, FileCustomRepository {
     @Modifying(clearAutomatically = true)
     @Query("delete from File f where f.post.id = :postId")
     void deleteFiles(@Param("postId") Long postId);

--- a/src/main/java/com/single/springboard/domain/file/impl/FileCustomRepositoryImpl.java
+++ b/src/main/java/com/single/springboard/domain/file/impl/FileCustomRepositoryImpl.java
@@ -1,0 +1,32 @@
+package com.single.springboard.domain.file.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.single.springboard.domain.file.File;
+import com.single.springboard.domain.file.FileCustomRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.single.springboard.domain.file.QFile.file;
+
+@RequiredArgsConstructor
+public class FileCustomRepositoryImpl implements FileCustomRepository {
+    private final JPAQueryFactory query;
+
+    @Override
+    public void deleteFilesByIds(List<Long> ids) {
+        query.delete(file)
+                .where(file.id.in(ids))
+                .execute();
+    }
+
+    @Override
+    public List<String> findFilesByIds(List<Long> ids) {
+        return query.select(file.translateName)
+                .from(file)
+                .where(file.id.in(ids))
+                .fetch();
+    }
+
+
+}

--- a/src/main/java/com/single/springboard/domain/post/Post.java
+++ b/src/main/java/com/single/springboard/domain/post/Post.java
@@ -47,10 +47,6 @@ public class Post extends BaseTimeEntity {
         this.content = updateRequest.content();
     }
 
-    public void updatePostFiles(List<File> files) {
-        this.files = files;
-    }
-
     public void increaseViewCount() {
         this.viewCount += 1;
     }

--- a/src/main/java/com/single/springboard/service/file/AwsS3Upload.java
+++ b/src/main/java/com/single/springboard/service/file/AwsS3Upload.java
@@ -60,11 +60,11 @@ public class AwsS3Upload {
 
     @Transactional
     // one request
-    public void delete(List<File> files) {
+    public void delete(List<String> fileUrls) {
         ArrayList<ObjectIdentifier> keys = new ArrayList<>();
-        for (File file : files) {
+        for (String fileUrl : fileUrls) {
             keys.add(ObjectIdentifier.builder()
-                    .key(file.getTranslateName())
+                    .key(fileUrl)
                     .build());
         }
 

--- a/src/main/java/com/single/springboard/service/user/CustomOAuth2UserService.java
+++ b/src/main/java/com/single/springboard/service/user/CustomOAuth2UserService.java
@@ -29,13 +29,12 @@ import static com.single.springboard.exception.ErrorCode.NOT_FOUND_USER;
 @RequiredArgsConstructor
 @Service
 public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private static final String UPLOAD_URL = "https://spring-board-file.s3.ap-northeast-2.amazonaws.com/";
+    private static final String TEMP_USER_NAME = "사용자";
     private final UserRepository userRepository;
     private final HttpSession httpSession;
     private final FileService fileService;
     private final UserUtils userUtils;
-
-    private static final String UPLOAD_URL = "https://spring-board-file.s3.ap-northeast-2.amazonaws.com/";
-    private static final String TEMP_USER_NAME = "사용자";
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
@@ -61,10 +60,10 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     private User saveOrLoadUser(OAuthAttributes attributes) {
         Optional<User> user = userRepository.findByEmail(attributes.getEmail());
 
-        if(user.isEmpty()) {
+        if (user.isEmpty()) {
             user = Optional.of(attributes.toEntity());
 
-            if(userRepository.existsByName(attributes.getName())) {
+            if (userRepository.existsByName(attributes.getName())) {
                 user.get().update(TEMP_USER_NAME + userUtils.getTemporaryUserNumber());
                 user.get().setSameName();
             }
@@ -75,16 +74,16 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
     @Transactional
     public void updateUser(UserUpdateRequest requestDto, SessionUser currentUser) {
-        if(requestDto.name().equals(currentUser.getName())) {
+        if (requestDto.name().equals(currentUser.getName())) {
             // 이름은 동일하고 이미지 파일만 변경하는 경우
-            userNameAndImageUpdate(requestDto);
+            userNameAndImageUpdate(currentUser.getPicture(), requestDto);
         } else {
             // 이름 or 이미지 파일을 변경하는 경우
-            if(existUsernameCheck(requestDto.name())) {
+            if (existUsernameCheck(requestDto.name())) {
 
                 throw new CustomException(IS_EXIST_USERNAME);
             }
-            userNameAndImageUpdate(requestDto);
+            userNameAndImageUpdate(currentUser.getPicture(), requestDto);
         }
     }
 
@@ -93,19 +92,15 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
     }
 
     @Transactional
-    public void userNameAndImageUpdate(UserUpdateRequest requestDto) {
+    public void userNameAndImageUpdate(String oldImageUrl, UserUpdateRequest requestDto) {
         User user = userRepository.findByEmail(requestDto.email())
                 .orElseThrow(() -> new CustomException(NOT_FOUND_USER));
 
-        if(requestDto.picture() != null && requestDto.picture().size() > 0) {
-            Optional<File> imageFile = fileService.findByTranslateName(user.getPicture());
-            List<File> imageList = new ArrayList<>();
+        if (requestDto.picture() != null && requestDto.picture().size() > 0) {
+            String imageUrl = fileService.userImageUpdate(oldImageUrl, requestDto.picture());
 
-            imageFile.ifPresent(imageList::add);
-
-            File translateFile = fileService.filesUpdate(imageList, requestDto.picture(), new HashMap<>()).get(0);
-            String imageUrl = UPLOAD_URL + translateFile.getTranslateName();
-            user.update(requestDto.name(), imageUrl);
+            String mergeUrl = UPLOAD_URL + imageUrl;
+            user.update(requestDto.name(), mergeUrl);
         } else {
             user.update(requestDto.name());
         }

--- a/src/main/java/com/single/springboard/util/FileUtils.java
+++ b/src/main/java/com/single/springboard/util/FileUtils.java
@@ -1,5 +1,6 @@
 package com.single.springboard.util;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.tika.Tika;
 import org.springframework.stereotype.Component;
@@ -11,8 +12,11 @@ import java.util.List;
 import java.util.UUID;
 
 @Slf4j
+@RequiredArgsConstructor
 @Component
 public class FileUtils {
+    private static final Tika tika = new Tika();
+
     public void fileMimeTypeCheck(final List<MultipartFile> multipartFiles) {
         for(MultipartFile multipartFile : multipartFiles) {
             String mimeType = getMimeType(multipartFile);
@@ -29,7 +33,6 @@ public class FileUtils {
     }
 
     private String getMimeType(MultipartFile multipartFile) {
-        Tika tika = new Tika();
         try {
             return tika.detect(multipartFile.getInputStream());
         } catch (IOException e) {

--- a/src/main/java/com/single/springboard/util/PostUtils.java
+++ b/src/main/java/com/single/springboard/util/PostUtils.java
@@ -1,0 +1,35 @@
+package com.single.springboard.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Component
+public class PostUtils {
+    private final ObjectMapper objectMapper;
+
+    public Map<Long, String> parseJsonStringToMap(String oldFileNameJson) {
+        Map<Long, String> oldFileMap = new HashMap<>();
+
+        try {
+            JsonNode jsonNode = objectMapper.readTree(oldFileNameJson);
+            Iterator<Map.Entry<String, JsonNode>> fields = jsonNode.fields();
+            while (fields.hasNext()) {
+                Map.Entry<String, JsonNode> next = fields.next();
+                String parseValue = String.valueOf(next.getValue()).replace("\"", "");
+                oldFileMap.put(Long.parseLong(next.getKey()), parseValue);
+            }
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        return oldFileMap;
+    }
+}

--- a/src/main/java/com/single/springboard/web/PostApiController.java
+++ b/src/main/java/com/single/springboard/web/PostApiController.java
@@ -1,15 +1,14 @@
 package com.single.springboard.web;
 
+import com.single.springboard.service.post.PostService;
 import com.single.springboard.service.user.LoginUser;
 import com.single.springboard.service.user.dto.SessionUser;
-import com.single.springboard.service.post.PostService;
 import com.single.springboard.web.dto.post.PostSaveRequest;
 import com.single.springboard.web.dto.post.PostUpdateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/v1/posts")
 @RestController
 public class PostApiController {
-
     private final PostService postService;
 
     @PostMapping
@@ -29,7 +27,6 @@ public class PostApiController {
 
     @PatchMapping("/{id}")
     public Long updatePost(@PathVariable Long id, @ModelAttribute @Valid PostUpdateRequest updateDto) {
-
         return postService.updatePost(id, updateDto);
     }
 

--- a/src/main/java/com/single/springboard/web/dto/post/PostUpdateRequest.java
+++ b/src/main/java/com/single/springboard/web/dto/post/PostUpdateRequest.java
@@ -1,6 +1,5 @@
 package com.single.springboard.web.dto.post;
 
-import com.single.springboard.service.file.dto.FilesNameDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import org.springframework.web.multipart.MultipartFile;
@@ -19,7 +18,7 @@ public record PostUpdateRequest(
 
         List<MultipartFile> files,
 
-        List<String> oldFileNames
+        String oldFileNames
 ) {
 
 }

--- a/src/main/resources/static/js/app/file.js
+++ b/src/main/resources/static/js/app/file.js
@@ -52,7 +52,7 @@ function deleteFile (e) {
     const filename = e.target.parentNode.childNodes[0].outerText;
 
     newFileArr = newFileArr.filter(item => filename !== item.name);
-    oldFileArr = oldFileArr.filter(item => filename !== item.name);
+    oldFileArr = oldFileArr.filter(item => filename !== item.originalName);
 
     const fileElement = e.target.parentNode;
     fileElement.remove();

--- a/src/main/resources/static/js/app/post.js
+++ b/src/main/resources/static/js/app/post.js
@@ -80,11 +80,11 @@ let post = {
 
     update : function () {
         const formData = this.createForm();
-        let oldFileObj = {};
+        let dtoObj = {};
         for (let i = 0; i < oldFileArr.length; i++) {
-            oldFileObj
+            dtoObj[oldFileArr[i].id] = oldFileArr[i].originalName;
         }
-        formData.append('oldFileNames', JSON.stringify(oldFileObj));
+        formData.append('oldFileNames', JSON.stringify(dtoObj));
 
         const id = $('#id').text();
 


### PR DESCRIPTION
Changes
---
- 기존 FileService의 updateFile 메서드를 유저 이미지와 게시글 파일 수정 메서드 2개로 분리.
- awsS3Upload의 delete메서드의 파라미터 타입 수정.(기존 List<File> -> List<String>)
- 파일 삭제 및 조회시 in절을 이용한 쿼리 생성