### PR TITLE
modified: 메인페이지 게시글 pagination no offset으로 설정

### DIFF
--- a/src/main/java/com/single/springboard/domain/comment/CommentCustomRepository.java
+++ b/src/main/java/com/single/springboard/domain/comment/CommentCustomRepository.java
@@ -6,5 +6,5 @@ import java.util.List;
 
 public interface CommentCustomRepository {
 
-    List<CommentPaginationDto> commentListPagination(Long commentId, String username, int pageSize);
+    List<CommentPaginationDto> commentListPaginationNoOffset(Long commentId, String username, int pageSize);
 }

--- a/src/main/java/com/single/springboard/domain/comment/impl/CommentCustomRepositoryImpl.java
+++ b/src/main/java/com/single/springboard/domain/comment/impl/CommentCustomRepositoryImpl.java
@@ -17,7 +17,7 @@ public class CommentCustomRepositoryImpl implements CommentCustomRepository {
     private final JPAQueryFactory query;
 
     @Override
-    public List<CommentPaginationDto> commentListPagination(Long commentId, String username, int pageSize) {
+    public List<CommentPaginationDto> commentListPaginationNoOffset(Long commentId, String username, int pageSize) {
         return query
                 .select(Projections.constructor(CommentPaginationDto.class,
                         comment.id.as("commentId"),

--- a/src/main/java/com/single/springboard/domain/post/PostCustomRepository.java
+++ b/src/main/java/com/single/springboard/domain/post/PostCustomRepository.java
@@ -1,6 +1,7 @@
 package com.single.springboard.domain.post;
 
-import com.single.springboard.domain.post.dto.PostPaginationDto;
+import com.single.springboard.domain.post.dto.PostListPaginationDto;
+import com.single.springboard.web.dto.post.PostsResponse;
 import com.single.springboard.web.dto.post.SearchResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -9,7 +10,9 @@ import java.util.List;
 
 public interface PostCustomRepository {
 
+    List<PostsResponse> findAllPostWithCommentsNoOffset(Long postId, int pageSize, boolean isLessThen);
+
     Page<SearchResponse> findAllByKeyword(String keyword, Pageable pageable);
 
-    List<PostPaginationDto> postListPagination(Long postId, String username, int pageSize);
+    List<PostListPaginationDto> postListPaginationNoOffset(Long postId, String username, int pageSize);
 }

--- a/src/main/java/com/single/springboard/domain/post/PostRepository.java
+++ b/src/main/java/com/single/springboard/domain/post/PostRepository.java
@@ -1,19 +1,10 @@
 package com.single.springboard.domain.post;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PostRepository extends JpaRepository<Post, Long>, PostCustomRepository {
-    @Query("SELECT p, COUNT(c) FROM Post p " +
-            "LEFT JOIN p.comments c " +
-            "LEFT JOIN FETCH p.user " +
-            "GROUP BY p " +
-            "ORDER BY p.id DESC")
-    Page<Object[]> findAllPostsWithCommentsCountAndUser(Pageable pageable);
-
     @Query("SELECT p from Post p " +
             "LEFT JOIN FETCH p.comments c " +
             "LEFT JOIN FETCH c.user " +

--- a/src/main/java/com/single/springboard/domain/post/dto/PostListPaginationDto.java
+++ b/src/main/java/com/single/springboard/domain/post/dto/PostListPaginationDto.java
@@ -1,0 +1,8 @@
+package com.single.springboard.domain.post.dto;
+
+public record PostListPaginationDto(
+        Long id,
+        String title,
+        long viewCount,
+        String createdDate
+) {}

--- a/src/main/java/com/single/springboard/domain/post/dto/PostPaginationDto.java
+++ b/src/main/java/com/single/springboard/domain/post/dto/PostPaginationDto.java
@@ -1,8 +1,36 @@
 package com.single.springboard.domain.post.dto;
 
-public record PostPaginationDto(
-        Long id,
-        String title,
-        long viewCount,
-        String createdDate
-) {}
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class PostPaginationDto {
+    private int currentPage;
+    private long totalPage;
+    private Long firstPostId;
+    private Long lastPostId;
+    private int size;
+    private boolean first;
+    private boolean last;
+
+    public int getPreviousPage() {
+        return currentPage > 1 ? currentPage - 1 : 1;
+    }
+
+    public int getNextPage() {
+        return currentPage < totalPage ? currentPage + 1 : 1;
+    }
+
+    public boolean isFirst() {
+        return currentPage == 1;
+    }
+
+    public boolean isLast() {
+        return currentPage == totalPage;
+    }
+
+    public int getSize() {
+        return size;
+    }
+}

--- a/src/main/java/com/single/springboard/domain/post/dto/RealPaginationDt.java
+++ b/src/main/java/com/single/springboard/domain/post/dto/RealPaginationDt.java
@@ -1,0 +1,18 @@
+package com.single.springboard.domain.post.dto;
+
+import com.single.springboard.web.dto.post.PostsResponse;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class RealPaginationDt {
+    private List<PostsResponse> postResponses;
+
+    private PostPaginationDto pagination;
+
+    public RealPaginationDt(List<PostsResponse> postResponses, PostPaginationDto paginationDto) {
+        this.postResponses = postResponses;
+        this.pagination = paginationDto;
+    }
+}

--- a/src/main/java/com/single/springboard/service/comment/CommentService.java
+++ b/src/main/java/com/single/springboard/service/comment/CommentService.java
@@ -70,6 +70,6 @@ public class CommentService {
     }
 
     public List<CommentPaginationDto> findWrittenCommentByUsername(SessionUser user, Long commentId) {
-        return commentRepository.commentListPagination(commentId, user.getName(), 10);
+        return commentRepository.commentListPaginationNoOffset(commentId, user.getName(), 10);
     }
 }

--- a/src/main/java/com/single/springboard/web/CommentApiController.java
+++ b/src/main/java/com/single/springboard/web/CommentApiController.java
@@ -1,10 +1,9 @@
 package com.single.springboard.web;
 
 import com.single.springboard.domain.comment.dto.CommentPaginationDto;
-import com.single.springboard.domain.post.dto.PostPaginationDto;
+import com.single.springboard.service.comment.CommentService;
 import com.single.springboard.service.user.LoginUser;
 import com.single.springboard.service.user.dto.SessionUser;
-import com.single.springboard.service.comment.CommentService;
 import com.single.springboard.web.dto.comment.CommentSaveRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/single/springboard/web/IndexController.java
+++ b/src/main/java/com/single/springboard/web/IndexController.java
@@ -5,7 +5,6 @@ import com.single.springboard.service.search.SearchService;
 import com.single.springboard.service.user.LoginUser;
 import com.single.springboard.service.user.dto.SessionUser;
 import com.single.springboard.web.dto.post.PostElementsResponse;
-import com.single.springboard.web.dto.post.PostResponse;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -28,8 +27,11 @@ public class IndexController {
     @GetMapping("/")
     public String index(Model model,
                         @LoginUser SessionUser user,
-                        Pageable pageable) {
-        model.addAttribute("posts", postService.findAllPostsAndCommentsCountDesc(pageable));
+                        @RequestParam(value = "isLessThen", defaultValue = "true") boolean isLessThen,
+                        @RequestParam(value = "page", defaultValue = "1") Integer currentPage,
+                        @RequestParam(value = "size", defaultValue = "20") Integer pageSize) {
+        model.addAttribute("posts",
+                postService.findAllPostAndCommentsCountDesc(currentPage, pageSize, isLessThen));
         model.addAttribute("ranking", postService.getPostsRanking());
         model.addAttribute("user", user);
 
@@ -47,8 +49,7 @@ public class IndexController {
     @PreAuthorize("isAuthenticated() and hasRole('ROLE_USER')")
     @GetMapping("/posts/update/{id}")
     public String postUpdate(@PathVariable Long id, Model model, @LoginUser SessionUser user) {
-        PostResponse post = postService.findPostById(id);
-        model.addAttribute("post", post);
+        model.addAttribute("post", postService.findPostById(id));
         model.addAttribute("user", user);
 
         return "post-update";

--- a/src/main/java/com/single/springboard/web/PostApiController.java
+++ b/src/main/java/com/single/springboard/web/PostApiController.java
@@ -1,6 +1,6 @@
 package com.single.springboard.web;
 
-import com.single.springboard.domain.post.dto.PostPaginationDto;
+import com.single.springboard.domain.post.dto.PostListPaginationDto;
 import com.single.springboard.service.post.PostService;
 import com.single.springboard.service.post.dto.CountResponse;
 import com.single.springboard.service.user.LoginUser;
@@ -49,7 +49,7 @@ public class PostApiController {
     }
 
     @GetMapping("/post-list")
-    public ResponseEntity<List<PostPaginationDto>> findPostList(
+    public ResponseEntity<List<PostListPaginationDto>> findPostList(
             @LoginUser SessionUser user,
             @RequestParam(value = "postId", required = false) Long postId) {
         return ResponseEntity.ok(postService.findWrittenPostByUsername(user, postId));

--- a/src/main/java/com/single/springboard/web/dto/post/PostsResponse.java
+++ b/src/main/java/com/single/springboard/web/dto/post/PostsResponse.java
@@ -8,8 +8,8 @@ public record PostsResponse(
         Long id,
         String title,
         String author,
-        long commentsCount,
-        long viewCount,
+        Long commentCount,
+        Long viewCount,
         String modifiedDate
 ) {
 

--- a/src/main/resources/static/js/app/post.js
+++ b/src/main/resources/static/js/app/post.js
@@ -1,6 +1,7 @@
 let post = {
     init: function () {
         let _this = this;
+
         $('.post-save_btn').on('click', () => {
             _this.save();
         });

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -35,7 +35,7 @@
     </a>
 </div>
 <div class="col-md-12">
-    <table class="table table-horizontal table-bordered">
+    <table id="post-table" class="table table-horizontal table-bordered">
         <thead class="thead-strong">
             <tr>
                 <th>게시글 번호</th>
@@ -46,11 +46,11 @@
             </tr>
         </thead>
         <tbody>
-            <tr th:each="p : ${posts}">
+            <tr th:each="p : ${posts.getPostResponses()}">
                 <td th:text="${p.id()}"></td>
                 <td>
                     <a th:href="${'/posts/find/' + p.id()}" th:text="${p.title()}"></a>
-                    <span th:text="'[' + ${p.commentsCount()} + ']'"></span>
+                    <span th:text="'[' + ${p.commentCount()} + ']'"></span>
                 </td>
                 <td th:text="${p.author()}"></td>
                 <td th:text="${p.viewCount()}"></td>
@@ -65,34 +65,48 @@
     </table>
 </div>
 
-<div th:if="${posts != null && posts.getTotalPages() > 1}" style="display: flex; justify-content: center">
+<div th:if="${posts != null && posts.getPagination().getTotalPage() > 1}" style="display: flex; justify-content: center">
     <nav aria-label="Page navigation">
         <ul class="pagination">
-            <li class="page-item" th:classappend="${posts.first ? 'disabled' : ''}">
-                <a class="page-link" th:href="@{/(page=${posts.first}, size=${posts.size})}" aria-label="First">
+            <li class="page-item" th:classappend="${posts.getPagination().isFirst() ? 'disabled' : ''}">
+                <a class="page-link" th:href="@{/(page=1, size=${posts.getPagination().size})}" aria-label="First">
                     <span aria-hidden="true">&laquo;</span>
-                    <span class="sr-only">처음으로</span>
+                    <span class="sr-only">맨처음으로</span>
                 </a>
             </li>
-            <li class="page-item" th:classappend="${posts.first ? 'disabled' : ''}">
-                <a class="page-link" th:href="@{/(page=${posts.number - 1}, size=${posts.size})}" aria-label="Previous">
+            <li class="page-item" th:classappend="${posts.getPagination().isFirst() ? 'disabled' : ''}">
+                <a class="page-link" th:href="@{/(
+                page=${posts.getPagination().getPreviousPage()}, size=${posts.getPagination().size},
+                isLessThen=false)}" aria-label="Previous">
                     <span aria-hidden="true"><</span>
                     <span class="sr-only">이전</span>
                 </a>
             </li>
-            <li th:each="pageNumber : ${#numbers.sequence((posts.number / 10) * 10, (posts.number / 10 == posts.totalPages / 10 ? posts.totalPages - 1 : ((posts.number / 10) * 10) + 9))}" th:classappend="${posts.number == pageNumber ? 'active' : ''}">
-                <a class="page-link" th:href="@{/(page=${pageNumber}, size=${posts.size})}" th:text="${pageNumber + 1}"></a>
+            <li th:each="pageNumber : ${#numbers.sequence(
+                (posts.getPagination().currentPage % 10 == 0 ?
+                posts.getPagination().currentPage - 9 :
+                (posts.getPagination().currentPage - (posts.getPagination().currentPage % 10)) + 1),
+                (posts.getPagination().currentPage % 10 == 0 ?
+                posts.getPagination.currentPage :
+                ((posts.getPagination().currentPage / 10) + 1) * 10))}"
+                th:classappend="${posts.getPagination().getCurrentPage() == pageNumber ? 'active' : ''}">
+                <a class="page-link" th:href="@{/(
+                page=${pageNumber},
+                size=${posts.getPagination().size})}" th:text="${pageNumber}"></a>
             </li>
-            <li class="page-item" th:classappend="${posts.last ? 'disabled' : ''}">
-                <a class="page-link" th:href="@{/(page=${posts.number + 1}, size=${posts.size})}" aria-label="Next">
+            <li class="page-item" th:classappend="${posts.getPagination().isLast() ? 'disabled' : ''}">
+                <a class="page-link" th:href="@{/(
+                page=${posts.getPagination().getNextPage()},size=${posts.getPagination().size},
+                isLessThen=true)}" aria-label="Next">
                     <span class="sr-only">다음</span>
                     <span aria-hidden="true">></span>
                 </a>
             </li>
-            <li class="page-item" th:classappend="${posts.last ? 'disabled' : ''}">
-                <a class="page-link" th:href="@{/(page=${posts.totalPages - 1}, size=${posts.size})}" aria-label="Last">
-                    <span aria-hidden="true">&raquo;</span>
+            <li class="page-item" th:classappend="${posts.getPagination().isLast() ? 'disabled' : ''}">
+                <a class="page-link" th:href="@{/(page=${posts.getPagination().getTotalPage()},
+                size=${posts.getPagination().size}, postId=1, isLessThen=false)}" aria-label="Last">
                     <span class="sr-only">마지막으로</span>
+                    <span aria-hidden="true">&raquo;</span>
                 </a>
             </li>
         </ul>

--- a/src/test/java/com/single/springboard/web/IndexControllerTest.java
+++ b/src/test/java/com/single/springboard/web/IndexControllerTest.java
@@ -2,7 +2,6 @@ package com.single.springboard.web;
 
 import com.single.springboard.domain.user.Role;
 import com.single.springboard.domain.user.User;
-import com.single.springboard.scheduler.RankingScheduler;
 import com.single.springboard.service.post.PostService;
 import com.single.springboard.service.post.dto.PostRankResponse;
 import com.single.springboard.service.search.SearchService;
@@ -42,9 +41,6 @@ class IndexControllerTest {
     @MockBean
     private SearchService searchService;
 
-    @MockBean
-    private RankingScheduler rankingScheduler;
-
     @Test
     @WithMockUser(username = "guestUser", roles = "GUEST")
     void index_unAuthorizedUser_loadSuccess() throws Exception {
@@ -54,7 +50,7 @@ class IndexControllerTest {
         Page<PostsResponse> page = new PageImpl<>(postsResponses, pageable, 0);
         List<PostRankResponse> postRankResponses = Collections.emptyList();
 
-        given(postService.findAllPostsAndCommentsCountDesc(pageable))
+        given(postService.findAllPostAndCommentsCountDesc(pageable))
                 .willReturn(page);
         given(rankingScheduler.getPostsRanking())
                 .willReturn(postRankResponses);
@@ -67,7 +63,7 @@ class IndexControllerTest {
                 .andExpect(model().attributeExists("posts", "ranking"))
                 .andExpect(model().attributeDoesNotExist( "user"));
 
-        verify(postService, times(1)).findAllPostsAndCommentsCountDesc(pageable);
+        verify(postService, times(1)).findAllPostAndCommentsCountDesc(pageable);
         verify(rankingScheduler, times(1)).getPostsRanking();
     }
 
@@ -91,7 +87,7 @@ class IndexControllerTest {
         MockHttpSession session = new MockHttpSession();
         session.setAttribute("user", new SessionUser(user));
 
-        given(postService.findAllPostsAndCommentsCountDesc(pageable))
+        given(postService.findAllPostAndCommentsCountDesc(pageable))
                 .willReturn(page);
         given(rankingScheduler.getPostsRanking())
                 .willReturn(postRankResponses);
@@ -104,7 +100,7 @@ class IndexControllerTest {
                 .andExpect(view().name("index"))
                 .andExpect(model().attributeExists("posts", "ranking", "user"));
 
-        verify(postService, times(1)).findAllPostsAndCommentsCountDesc(pageable);
+        verify(postService, times(1)).findAllPostAndCommentsCountDesc(pageable);
         verify(rankingScheduler, times(1)).getPostsRanking();
     }
 }


### PR DESCRIPTION
Changes
---
- 기존 pageable을 이용하여 offset으로 게시글 페이징 처리 -> nooffset으로 pagination 처리

Background
---
- DB 쿼리에서 gt 비교를 할 때 제일 최신 id가 10000이고 정렬은 id desc로 되어 있다고 가정할 때 id가 9900이고 limit이 20인 데이터를 select할 경우 9901부터 가져올거라고 예상 하였으나 제일 최신 id 10000부터 limit 20만큼 select되는걸 알게됨.