### PR TITLE
fix: pagination 다음 이전 버튼 클릭 시 에러 발생으로 수정. pageSize에 맞게 동적으로 설정 처리 완료

### DIFF
--- a/src/main/java/com/single/springboard/domain/post/PostCustomRepository.java
+++ b/src/main/java/com/single/springboard/domain/post/PostCustomRepository.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public interface PostCustomRepository {
 
-    List<PostsResponse> findAllPostWithCommentsNoOffset(Long postId, int pageSize, boolean isLessThen);
+    List<PostsResponse> findAllPostWithCommentsNoOffset(Long postId, int pageSize);
 
     Page<SearchResponse> findAllByKeyword(String keyword, Pageable pageable);
 

--- a/src/main/java/com/single/springboard/domain/post/dto/PostPaginationDto.java
+++ b/src/main/java/com/single/springboard/domain/post/dto/PostPaginationDto.java
@@ -8,8 +8,6 @@ import lombok.Getter;
 public class PostPaginationDto {
     private int currentPage;
     private long totalPage;
-    private Long firstPostId;
-    private Long lastPostId;
     private int size;
     private boolean first;
     private boolean last;

--- a/src/main/java/com/single/springboard/domain/post/impl/PostCustomRepositoryImpl.java
+++ b/src/main/java/com/single/springboard/domain/post/impl/PostCustomRepositoryImpl.java
@@ -25,7 +25,7 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
     private final JPAQueryFactory query;
 
     @Override
-    public List<PostsResponse> findAllPostWithCommentsNoOffset(Long postId, int pageSize, boolean isLessThen) {
+    public List<PostsResponse> findAllPostWithCommentsNoOffset(Long postId, int pageSize) {
         return query
                 .select(Projections.constructor(PostsResponse.class,
                         post.id.as("postId"),
@@ -37,9 +37,9 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .from(post)
                 .leftJoin(comment)
                 .on(comment.post.id.eq(post.id))
-                .where(isLessThen ? ltPostId(postId) : gtPostId(postId))
+                .where(loePostId(postId))
                 .groupBy(post.id)
-                .orderBy(isLessThen ? post.id.desc() : post.id.asc())
+                .orderBy(post.id.desc())
                 .limit(pageSize)
                 .fetch();
     }
@@ -94,19 +94,19 @@ public class PostCustomRepositoryImpl implements PostCustomRepository {
                 .fetch();
     }
 
+    private BooleanExpression loePostId(Long postId) {
+        if(postId == null) {
+            return null;
+        }
+
+        return post.id.loe(postId);
+    }
+
     private BooleanExpression ltPostId(Long postId) {
         if(postId == null) {
             return null;
         }
 
         return post.id.lt(postId);
-    }
-
-    private BooleanExpression gtPostId(Long postId) {
-        if(postId == null) {
-            return null;
-        }
-
-        return post.id.gt(postId);
     }
 }

--- a/src/main/java/com/single/springboard/service/post/PostService.java
+++ b/src/main/java/com/single/springboard/service/post/PostService.java
@@ -124,30 +124,24 @@ public class PostService {
     }
 
     @Transactional(readOnly = true)
-    public RealPaginationDt findAllPostAndCommentsCountDesc(int currentPage, int pageSize, boolean isLessThen) {
-        Long postId = currentPage == 1 ? postTotalCount.get() : postTotalCount.get() - ((long) currentPage *  pageSize);
-        List<PostsResponse> postsResponse = postRepository.findAllPostWithCommentsNoOffset(postId, pageSize, isLessThen);
+    public RealPaginationDt findAllPostAndCommentsCountDesc(int currentPage, int pageSize) {
+        Long postId = currentPage == 1 ? null : postTotalCount.get() - ((long) (currentPage - 1) * pageSize);
+
+        List<PostsResponse> postsResponse = postRepository.findAllPostWithCommentsNoOffset(postId, pageSize);
 
         PostPaginationDto postPaginationDto;
 
         if(postsResponse.size() > 0) {
-            if(!isLessThen) {
-                Collections.reverse(postsResponse);
-            }
             postPaginationDto = PostPaginationDto.builder()
                     .currentPage(currentPage)
-                    .firstPostId(postsResponse.get(0).id())
-                    .lastPostId(postsResponse.get(postsResponse.size() - 1).id())
                     .size(pageSize)
-                    .totalPage((postTotalCount.get() / 20) >= 1 ? (postTotalCount.get() / 20) + 1 : 0)
+                    .totalPage((postTotalCount.get() / pageSize) >= 1 ? (postTotalCount.get() / pageSize) + 1 : 0)
                     .build();
         } else {
             postPaginationDto = PostPaginationDto.builder()
                     .currentPage(currentPage)
-                    .firstPostId(null)
-                    .lastPostId(null)
                     .size(pageSize)
-                    .totalPage((postTotalCount.get() / 20) >= 1 ? (postTotalCount.get() / 20) + 1 : 0)
+                    .totalPage((postTotalCount.get() / pageSize) >= 1 ? (postTotalCount.get() / pageSize) + 1 : 0)
                     .build();
         }
 

--- a/src/main/java/com/single/springboard/web/IndexController.java
+++ b/src/main/java/com/single/springboard/web/IndexController.java
@@ -27,11 +27,9 @@ public class IndexController {
     @GetMapping("/")
     public String index(Model model,
                         @LoginUser SessionUser user,
-                        @RequestParam(value = "isLessThen", defaultValue = "true") boolean isLessThen,
                         @RequestParam(value = "page", defaultValue = "1") Integer currentPage,
                         @RequestParam(value = "size", defaultValue = "20") Integer pageSize) {
-        model.addAttribute("posts",
-                postService.findAllPostAndCommentsCountDesc(currentPage, pageSize, isLessThen));
+        model.addAttribute("posts", postService.findAllPostAndCommentsCountDesc(currentPage, pageSize));
         model.addAttribute("ranking", postService.getPostsRanking());
         model.addAttribute("user", user);
 

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -76,8 +76,7 @@
             </li>
             <li class="page-item" th:classappend="${posts.getPagination().isFirst() ? 'disabled' : ''}">
                 <a class="page-link" th:href="@{/(
-                page=${posts.getPagination().getPreviousPage()}, size=${posts.getPagination().size},
-                isLessThen=false)}" aria-label="Previous">
+                page=${posts.getPagination().getPreviousPage()}, size=${posts.getPagination().size})}" aria-label="Previous">
                     <span aria-hidden="true"><</span>
                     <span class="sr-only">이전</span>
                 </a>
@@ -86,7 +85,7 @@
                 (posts.getPagination().currentPage % 10 == 0 ?
                 posts.getPagination().currentPage - 9 :
                 (posts.getPagination().currentPage - (posts.getPagination().currentPage % 10)) + 1),
-                (posts.getPagination().currentPage % 10 == 0 ?
+                (posts.getPagination().currentPage % 10 == 0 || posts.getPagination.isLast ?
                 posts.getPagination.currentPage :
                 ((posts.getPagination().currentPage / 10) + 1) * 10))}"
                 th:classappend="${posts.getPagination().getCurrentPage() == pageNumber ? 'active' : ''}">
@@ -96,15 +95,14 @@
             </li>
             <li class="page-item" th:classappend="${posts.getPagination().isLast() ? 'disabled' : ''}">
                 <a class="page-link" th:href="@{/(
-                page=${posts.getPagination().getNextPage()},size=${posts.getPagination().size},
-                isLessThen=true)}" aria-label="Next">
+                page=${posts.getPagination().getNextPage()},size=${posts.getPagination().size})}" aria-label="Next">
                     <span class="sr-only">다음</span>
                     <span aria-hidden="true">></span>
                 </a>
             </li>
             <li class="page-item" th:classappend="${posts.getPagination().isLast() ? 'disabled' : ''}">
                 <a class="page-link" th:href="@{/(page=${posts.getPagination().getTotalPage()},
-                size=${posts.getPagination().size}, postId=1, isLessThen=false)}" aria-label="Last">
+                size=${posts.getPagination().size}, postId=1)}" aria-label="Last">
                     <span class="sr-only">마지막으로</span>
                     <span aria-hidden="true">&raquo;</span>
                 </a>


### PR DESCRIPTION
Changes
---
- pageSize에 맞게 동적으로 게시글이 보여지도록 구현
- 이전, 다음 버튼 클릭 시 게시글 id에 맞게 출력되지 않아 수정 처리.