### PR TITLE
refactor: 비즈니스 로직에 있는 redisTemplate 분리

### DIFF
--- a/src/main/java/com/single/springboard/client/RedisClient.java
+++ b/src/main/java/com/single/springboard/client/RedisClient.java
@@ -1,0 +1,106 @@
+package com.single.springboard.client;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.single.springboard.domain.post.Post;
+import com.single.springboard.exception.CustomException;
+import com.single.springboard.service.post.dto.PostRankResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.single.springboard.exception.ErrorCode.POST_CHANGE_FAIL;
+import static com.single.springboard.service.post.constants.PostKeys.RANKING;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class RedisClient {
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public <T> T get(Long key, Class<T> classType) {
+        return get(key.toString(), classType);
+    }
+
+    private <T> T get(String key, Class<T> classType) {
+        String redisValue = (String) redisTemplate.opsForValue().get(key);
+        if (ObjectUtils.isEmpty(redisValue)) {
+            return null;
+        } else {
+            try {
+                return mapper.readValue(redisValue, classType);
+            } catch (JsonProcessingException e) {
+                log.error("Parsing Error", e);
+                return null;
+            }
+        }
+    }
+
+    public void put(Long key, Post post) {
+        put(key.toString(), post);
+    }
+
+    private void put(String key, Post post) {
+        try {
+            redisTemplate.opsForValue().set(key, mapper.writeValueAsString(post));
+        } catch (JsonProcessingException e) {
+            log.error(e.getMessage());
+            throw new CustomException(POST_CHANGE_FAIL);
+        }
+    }
+
+    public void delete(Long key) {
+        redisTemplate.delete(key.toString());
+    }
+
+    public void delete(List<Long> key) {
+        redisTemplate.delete(key.stream()
+                .map(Object::toString)
+                .collect(Collectors.toList()
+                ));
+    }
+
+    public void increasePostViewCount(String userId, Post post) {
+        String postId = post.getId().toString();
+        boolean hasViewed = Boolean.TRUE.equals(redisTemplate.opsForSet().isMember(userId, postId));
+
+        if (!hasViewed) {
+            redisTemplate.opsForZSet().incrementScore(RANKING.getKey(), post.getTitle() + ":" + postId, 1);
+            redisTemplate.opsForSet().add(userId, postId);
+            post.increaseViewCount();
+        }
+    }
+
+    public List<PostRankResponse> getPostsRanking() {
+        ZSetOperations<String, Object> zSetOperations = redisTemplate.opsForZSet();
+        Set<ZSetOperations.TypedTuple<Object>> typedTuples =
+                zSetOperations.reverseRangeWithScores(RANKING.getKey(), 0, 4);
+
+        List<PostRankResponse> responses = new ArrayList<>();
+        if (typedTuples != null) {
+            List<PostRankResponse> list = typedTuples.stream()
+                    .map(tuple -> {
+                        String[] splitValue = String.valueOf(tuple.getValue()).split(":");
+                        return PostRankResponse.builder()
+                                .id(Long.parseLong(splitValue[splitValue.length - 1]))
+                                .title(splitValue[0])
+                                .score(tuple.getScore().longValue())
+                                .build();
+                    })
+                    .toList();
+
+            responses.addAll(list);
+        }
+
+        return responses;
+    }
+}

--- a/src/main/java/com/single/springboard/domain/BaseTimeEntity.java
+++ b/src/main/java/com/single/springboard/domain/BaseTimeEntity.java
@@ -1,5 +1,9 @@
 package com.single.springboard.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
@@ -17,11 +21,15 @@ import java.time.LocalDateTime;
 public class BaseTimeEntity {
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @CreatedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdDate;
 
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @LastModifiedDate
     @Column(nullable = false, updatable = false)
     private LocalDateTime modifiedDate;

--- a/src/main/java/com/single/springboard/domain/comment/Comment.java
+++ b/src/main/java/com/single/springboard/domain/comment/Comment.java
@@ -1,5 +1,6 @@
 package com.single.springboard.domain.comment;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.single.springboard.domain.BaseTimeEntity;
 import com.single.springboard.domain.post.Post;
 import com.single.springboard.domain.user.User;
@@ -33,10 +34,12 @@ public class Comment extends BaseTimeEntity {
     private int commentLevel;
 
     @ManyToOne
+    @JsonBackReference
     @JoinColumn(name = "post_id")
     private Post post;
 
     @ManyToOne
+    @JsonBackReference
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/single/springboard/domain/file/File.java
+++ b/src/main/java/com/single/springboard/domain/file/File.java
@@ -1,5 +1,6 @@
 package com.single.springboard.domain.file;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.single.springboard.domain.post.Post;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -21,6 +22,7 @@ public class File {
     private Long id;
 
     @ManyToOne
+    @JsonBackReference
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/src/main/java/com/single/springboard/domain/post/Post.java
+++ b/src/main/java/com/single/springboard/domain/post/Post.java
@@ -1,18 +1,18 @@
 package com.single.springboard.domain.post;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.single.springboard.domain.BaseTimeEntity;
 import com.single.springboard.domain.comment.Comment;
 import com.single.springboard.domain.file.File;
 import com.single.springboard.domain.user.User;
 import com.single.springboard.web.dto.post.PostUpdateRequest;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
+@ToString
 @Builder
 @Getter
 @AllArgsConstructor
@@ -34,13 +34,16 @@ public class Post extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<File> files;
 
+    @JsonManagedReference
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> comments;
 
     @ManyToOne
+    @JsonBackReference
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/single/springboard/domain/user/User.java
+++ b/src/main/java/com/single/springboard/domain/user/User.java
@@ -1,5 +1,7 @@
 package com.single.springboard.domain.user;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.single.springboard.domain.BaseTimeEntity;
 import com.single.springboard.domain.comment.Comment;
 import com.single.springboard.domain.post.Post;
@@ -39,9 +41,11 @@ public class User extends BaseTimeEntity {
     private Role role;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE,orphanRemoval = true)
+    @JsonBackReference
     private List<Comment> comments;
 
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
+    @JsonManagedReference
     private List<Post> posts;
 
     public User update(String name, String picture) {

--- a/src/main/java/com/single/springboard/exception/ErrorCode.java
+++ b/src/main/java/com/single/springboard/exception/ErrorCode.java
@@ -12,7 +12,8 @@ public enum ErrorCode {
     UNAUTHORIZED_USER_REQUIRED_LOGIN(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
     IS_EXIST_USERNAME(HttpStatus.BAD_REQUEST, "이미 사용중인 이름입니다. 이름을 다시 수정 해주세요."),
     EXIST_USERNAME_SET_TEMPORARY_NAME(HttpStatus.BAD_REQUEST, "회원 가입은 완료 되었으나 이미 사용중인 이름이 있습니다. 프로필 수정을 해주세요."),
-    IS_WRONG_ACCESS(HttpStatus.BAD_REQUEST, "잘못된 접근입니다.");
+    IS_WRONG_ACCESS(HttpStatus.BAD_REQUEST, "잘못된 접근입니다."),
+    POST_CHANGE_FAIL(HttpStatus.BAD_REQUEST, "게시글을 추가/변경할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String content;

--- a/src/main/java/com/single/springboard/service/post/constants/PostKeys.java
+++ b/src/main/java/com/single/springboard/service/post/constants/PostKeys.java
@@ -1,9 +1,7 @@
 package com.single.springboard.service.post.constants;
 
 public enum PostKeys {
-    RANKING("ranking"),
-    USER_VIEW("post:view:user:"),
-    POST_TOTAL_COUNT("post:total:count");
+    RANKING("ranking");
 
     private final String key;
 

--- a/src/main/java/com/single/springboard/service/search/SearchService.java
+++ b/src/main/java/com/single/springboard/service/search/SearchService.java
@@ -29,7 +29,7 @@ public class SearchService {
     public List<PostDocumentResponse> findPostsByKeyword(String keyword) {
         NativeQuery searchQuery = new NativeQueryBuilder()
                 .withQuery(q ->
-                        q.bool(builder -> builder.should(
+                        q.bool(b -> b.should(
                                 match(m -> m.field("title").query(keyword)),
                                 match(m -> m.field("content").query(keyword)),
                                 match(m -> m.field("author").query(keyword))

--- a/src/main/java/com/single/springboard/web/IndexController.java
+++ b/src/main/java/com/single/springboard/web/IndexController.java
@@ -1,11 +1,12 @@
 package com.single.springboard.web;
 
+import com.single.springboard.client.RedisClient;
 import com.single.springboard.domain.post.dto.PostDocumentResponse;
 import com.single.springboard.service.post.PostService;
 import com.single.springboard.service.search.SearchService;
 import com.single.springboard.service.user.LoginUser;
 import com.single.springboard.service.user.dto.SessionUser;
-import com.single.springboard.web.dto.post.PostWithElementsResponse;
+import com.single.springboard.web.dto.post.PostDetailResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -22,6 +23,7 @@ import java.util.List;
 public class IndexController {
     private final PostService postService;
     private final SearchService searchService;
+    private final RedisClient redisClient;
 
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_GUEST')")
     @GetMapping("/")
@@ -29,7 +31,7 @@ public class IndexController {
                         @LoginUser SessionUser user,
                         Pageable pageable) {
         model.addAttribute("posts", postService.findAllPostAndCommentsCountDesc(pageable));
-        model.addAttribute("ranking", postService.getPostsRanking());
+        model.addAttribute("ranking", redisClient.getPostsRanking());
         model.addAttribute("user", user);
 
         return "index";
@@ -55,7 +57,7 @@ public class IndexController {
     @PreAuthorize("hasRole('ROLE_USER') or hasRole('ROLE_GUEST')")
     @GetMapping("/posts/find/{id}")
     public String postFind(@PathVariable Long id, Model model, @LoginUser SessionUser user) {
-        PostWithElementsResponse post = postService.findPostDetail(id, user);
+        PostDetailResponse post = postService.findPostDetail(id, user);
         model.addAttribute("post", post);
         model.addAttribute("user", user);
         model.addAttribute("comments", post.comments());

--- a/src/main/java/com/single/springboard/web/dto/post/PostDetailResponse.java
+++ b/src/main/java/com/single/springboard/web/dto/post/PostDetailResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import java.util.List;
 
 @Builder
-public record PostWithElementsResponse(
+public record PostDetailResponse(
         Long id,
         String author,
         String content,


### PR DESCRIPTION
Changes
---
- 비즈니스 로직에 있는 redisTemplate을 redisClient 파일로 분리 처리
- 캐싱 전략 수정
- Json 직렬화/역직렬화 시 양방향 관계에 순환 참조 에러 발생으로 @JsonManagedReference , @JsonBackReference 어노테이션 정의
- LocalDateTime 직렬화/역직렬화 에러에 대한 해결(BaseTimeEntity 어노테이션 정의)