### PR TITLE
fix: 기존 캐시가 정상적으로 되지 않는 부분 수정

### DIFF
--- a/src/main/java/com/single/springboard/SpringBoardApplication.java
+++ b/src/main/java/com/single/springboard/SpringBoardApplication.java
@@ -2,7 +2,9 @@ package com.single.springboard;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
+@EnableCaching
 @SpringBootApplication
 public class SpringBoardApplication {
 

--- a/src/main/java/com/single/springboard/client/constants/PostKeys.java
+++ b/src/main/java/com/single/springboard/client/constants/PostKeys.java
@@ -1,8 +1,8 @@
-package com.single.springboard.service.post.constants;
+package com.single.springboard.client.constants;
 
 public enum PostKeys {
     RANKING("ranking"),
-    POST_ID_KEY("post:post_id:");
+    POSTS_KEY("posts");
 
     private final String key;
 

--- a/src/main/java/com/single/springboard/config/RedisConfig.java
+++ b/src/main/java/com/single/springboard/config/RedisConfig.java
@@ -1,12 +1,17 @@
 package com.single.springboard.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -36,5 +41,18 @@ public class RedisConfig {
         redisTemplate.setHashValueSerializer(serializer);
 
         return redisTemplate;
+    }
+
+    @Bean
+    public CacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair
+                        .fromSerializer(new GenericJackson2JsonRedisSerializer()));
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
     }
 }

--- a/src/main/java/com/single/springboard/config/SecurityConfig.java
+++ b/src/main/java/com/single/springboard/config/SecurityConfig.java
@@ -71,7 +71,7 @@ public class SecurityConfig {
         http.sessionManagement(session -> {
             session.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED);
             session.invalidSessionUrl("/");
-            session.sessionFixation().migrateSession();
+            session.sessionFixation().changeSessionId();
         });
 
         return http.build();

--- a/src/main/java/com/single/springboard/domain/comment/Comment.java
+++ b/src/main/java/com/single/springboard/domain/comment/Comment.java
@@ -1,6 +1,7 @@
 package com.single.springboard.domain.comment;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.single.springboard.domain.BaseTimeEntity;
 import com.single.springboard.domain.post.Post;
 import com.single.springboard.domain.user.User;
@@ -33,20 +34,22 @@ public class Comment extends BaseTimeEntity {
 
     private int commentLevel;
 
+    @JsonBackReference(value = "post-comments")
     @ManyToOne
-    @JsonBackReference
     @JoinColumn(name = "post_id")
     private Post post;
 
+    @JsonBackReference(value = "user-comments")
     @ManyToOne
-    @JsonBackReference
     @JoinColumn(name = "user_id")
     private User user;
 
+    @JsonBackReference(value = "parent-child_comment")
     @ManyToOne
-    @JoinColumn(name = "parent_comment_id", referencedColumnName = "id", updatable = false)
+    @JoinColumn(name = "parent_comment_id", referencedColumnName = "id")
     private Comment parentComment;
 
+    @JsonManagedReference(value = "parent-child_comment")
     @OneToMany(mappedBy = "parentComment", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> children = new ArrayList<>();
 }

--- a/src/main/java/com/single/springboard/domain/file/File.java
+++ b/src/main/java/com/single/springboard/domain/file/File.java
@@ -26,7 +26,7 @@ public class File {
     private Long id;
 
     @ManyToOne
-    @JsonBackReference
+    @JsonBackReference(value = "post-files")
     @JoinColumn(name = "post_id")
     private Post post;
 

--- a/src/main/java/com/single/springboard/domain/post/Post.java
+++ b/src/main/java/com/single/springboard/domain/post/Post.java
@@ -34,16 +34,16 @@ public class Post extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    @JsonManagedReference
+    @JsonManagedReference(value = "post-files")
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
     private List<File> files;
 
-    @JsonManagedReference
+    @JsonManagedReference(value = "post-comments")
     @OneToMany(mappedBy = "post", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<Comment> comments;
 
     @ManyToOne
-    @JsonBackReference
+    @JsonBackReference(value = "post-user")
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/single/springboard/domain/user/User.java
+++ b/src/main/java/com/single/springboard/domain/user/User.java
@@ -40,12 +40,12 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false, updatable = false)
     private Role role;
 
+    @JsonManagedReference("user-comments")
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE,orphanRemoval = true)
-    @JsonBackReference
     private List<Comment> comments;
 
+    @JsonManagedReference("post-user")
     @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.REMOVE, orphanRemoval = true)
-    @JsonManagedReference
     private List<Post> posts;
 
     public User update(String name, String picture) {

--- a/src/main/java/com/single/springboard/util/CommentUtils.java
+++ b/src/main/java/com/single/springboard/util/CommentUtils.java
@@ -1,19 +1,38 @@
 package com.single.springboard.util;
 
 import com.single.springboard.domain.comment.Comment;
+import com.single.springboard.domain.post.Post;
 import com.single.springboard.service.user.dto.SessionUser;
+import com.single.springboard.web.dto.comment.CommentsResponse;
 import org.springframework.stereotype.Component;
 
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 @Component
 public class CommentUtils {
+    public List<CommentsResponse> createCommentsResponses(List<Comment> comments, Post post, SessionUser user) {
+        return commentsSort(comments).stream()
+                .map(comment -> CommentsResponse.builder()
+                        .id(comment.getId())
+                        .commentLevel(comment.getCommentLevel())
+                        .parentId(comment.getParentComment())
+                        .content(comment.isSecret() ? this.enableSecretCommentView(post.getAuthor(),
+                                user.getName(), comment.getAuthor()) ?
+                                comment.getContent() : "비밀 댓글 입니다." : comment.getContent())
+                        .author(comment.getAuthor())
+                        .createdDate(comment.getCreatedDate().format(
+                                DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")
+                        ))
+                        .build())
+                .toList();
+    }
 
-    public List<Comment> commentsSort(List<Comment> comments) {
+    private List<Comment> commentsSort(List<Comment> comments) {
         List<Comment> sortedComments = new ArrayList<>();
 
-        Collections.sort(comments, (Comment c1, Comment c2) -> {
-            if(c1.getId() < c2.getId()) return 1;
+        comments.sort((Comment c1, Comment c2) -> {
+            if (c1.getId() < c2.getId()) return 1;
             else return -1;
         });
 
@@ -45,12 +64,12 @@ public class CommentUtils {
             }
         }
 
-        Collections.sort(children, Comparator.comparingLong(Comment::getId));
+        children.sort(Comparator.comparingLong(Comment::getId));
 
         return children;
     }
 
-    public boolean enableSecretCommentView(String postAuthor, String currentUser, String commentAuthor) {
+    private boolean enableSecretCommentView(String postAuthor, String currentUser, String commentAuthor) {
         return postAuthor.equals(currentUser) || commentAuthor.equals(currentUser);
     }
 }

--- a/src/main/java/com/single/springboard/web/CommentApiController.java
+++ b/src/main/java/com/single/springboard/web/CommentApiController.java
@@ -7,6 +7,7 @@ import com.single.springboard.service.user.dto.SessionUser;
 import com.single.springboard.web.dto.comment.CommentSaveRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,9 +20,10 @@ public class CommentApiController {
     private final CommentService commentService;
 
     @PostMapping
-    public ResponseEntity<Long> commentSave(@RequestBody @Valid CommentSaveRequest requestDto,
-                                            @LoginUser SessionUser user) {
-        return ResponseEntity.ok(commentService.commentSave(requestDto, user.getEmail()));
+    public ResponseEntity<Void> commentSave(@RequestBody @Valid CommentSaveRequest requestDto,
+                                                          @LoginUser SessionUser user) {
+        commentService.commentSave(requestDto, user);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/com/single/springboard/web/IndexController.java
+++ b/src/main/java/com/single/springboard/web/IndexController.java
@@ -9,7 +9,6 @@ import com.single.springboard.web.dto.post.PostDetailResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/resources/static/js/app/comment.js
+++ b/src/main/resources/static/js/app/comment.js
@@ -30,7 +30,8 @@ let comment = {
             url: '/api/v1/comments',
             dataType: 'json',
             contentType: 'application/json; charset=utf-8',
-            data: JSON.stringify(data)
+            data: JSON.stringify(data),
+            async: false
         }).done(function () {
             alert("댓글이 등록되었습니다.");
             window.location.href = '/posts/find/' + data.postId;
@@ -61,7 +62,8 @@ let comment = {
             url: '/api/v1/comments',
             dataType: 'json',
             contentType:'application/json; charset=utf-8',
-            data: JSON.stringify(data)
+            data: JSON.stringify(data),
+            async: false
         }).done(function () {
             alert("댓글이 등록 되었습니다.");
             window.location.href = '/posts/find/' + data.postId;


### PR DESCRIPTION
Changes
---
## Backend
### 캐시가 적용이 되지 않는 것을 확인하여 수정.
- 게시글 업데이트 및 댓글 삽입 시 해당 캐시 삭제
- 기존 redis의 Strings 자료 구조에서 Hash로 변경
- 댓글은 

## Frontend
### 댓글 저장 시 버그 발생
- 최초에 댓글 등록 시 페이지에 바로 적용이 되지 않고 2번에 걸쳐 저장을 해야 페이지에 적용이 됨. 해당 이유는 ajax의 비동기 통신에 대한 문제로 확인되어 async: false 처리 후 확인 완료

